### PR TITLE
[8.0][IMP] Purchase with consignor supplier are not to be invoiced

### DIFF
--- a/recurring_consignment/models/__init__.py
+++ b/recurring_consignment/models/__init__.py
@@ -11,6 +11,7 @@ from . import pos_order
 from . import product_pricelist
 from . import product_product
 from . import product_template
+from . import purchase_order
 from . import res_partner
 from . import sale_order
 from . import sale_order_line

--- a/recurring_consignment/models/purchase_order.py
+++ b/recurring_consignment/models/purchase_order.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (C) 2015 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# @author: Quentin DUPONT (https://twitter.com/pondupont)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    consignment_trade = fields.Boolean(
+        string='Consignment Trade', related='partner_id.is_consignor')
+
+    # Override Section
+    # Make purchase order not to be invoiced
+    @api.model
+    def _prepare_order_line_move(
+            self, order, order_line, picking_id, group_id):
+        res = super(PurchaseOrder, self)._prepare_order_line_move(
+            order, order_line, picking_id, group_id)
+        if order.consignment_trade:
+            for item in res:
+                item['invoice_state'] = 'none'
+        return res

--- a/stock_picking_mass_change/models/stock_picking_mass_change_wizard.py
+++ b/stock_picking_mass_change/models/stock_picking_mass_change_wizard.py
@@ -142,5 +142,6 @@ class StockPickingMassChangeWizard(models.TransientModel):
                     line.move_id.name, line.move_id.product_qty,
                     line.target_qty),
                 'product_uom_qty': line.target_qty,
+                'product_uos_qty': line.target_qty,
                 'product_uom': self.product_uom_id.id,
             })


### PR DESCRIPTION
Each order_line move of the purchase is set to "none" for invoice_state.
Thus, the picking is not to be invoiced