### PR TITLE
[8.0][IMP] patch to avoid zero division error

### DIFF
--- a/account_invoice_supplierinfo_update_standard_price/i18n/fr.po
+++ b/account_invoice_supplierinfo_update_standard_price/i18n/fr.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* account_invoice_supplierinfo_update_standard_price
+#   * account_invoice_supplierinfo_update_standard_price
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-08 22:10+0000\n"
-"PO-Revision-Date: 2018-03-08 22:10+0000\n"
+"POT-Creation-Date: 2019-03-15 11:03+0000\n"
+"PO-Revision-Date: 2019-03-15 11:03+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -28,11 +28,6 @@ msgid "Current Standard Price"
 msgstr "Prix de revient actuel"
 
 #. module: account_invoice_supplierinfo_update_standard_price
-#: model:product.template,name:account_invoice_supplierinfo_update_standard_price.transport_costs_product_product_template
-msgid "Demo Transport costs"
-msgstr "Demo Transport costs"
-
-#. module: account_invoice_supplierinfo_update_standard_price
 #: field:account.invoice,distributed_expense_total:0
 msgid "Distributed Expenses Total"
 msgstr "Total des charges réparties"
@@ -50,7 +45,7 @@ msgstr "Facture"
 #. module: account_invoice_supplierinfo_update_standard_price
 #: model:ir.model,name:account_invoice_supplierinfo_update_standard_price.model_account_invoice_line
 msgid "Invoice Line"
-msgstr "Ligne de facture"
+msgstr "Lignes de facture"
 
 #. module: account_invoice_supplierinfo_update_standard_price
 #: field:wizard.update.invoice.supplierinfo.line,new_standard_price:0
@@ -68,7 +63,12 @@ msgid "Product Template"
 msgstr "Modèle d'article"
 
 #. module: account_invoice_supplierinfo_update_standard_price
+#: code:addons/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py:32
+#, python-format
+msgid "We can't check prices for a invoice whose total is null"
+msgstr "On ne peut pas vérifier les prix pour une facture nulle."
+
+#. module: account_invoice_supplierinfo_update_standard_price
 #: view:account.invoice:account_invoice_supplierinfo_update_standard_price.view_account_invoice_form
 msgid "oe_subtotal_footer_separator"
 msgstr "oe_subtotal_footer_separator"
-

--- a/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py
@@ -3,8 +3,9 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, models
+from openerp import _, api, models
 from openerp.tools.float_utils import float_compare
+from openerp.exceptions import Warning as UserError
 
 
 class AccountInvoiceLine(models.Model):
@@ -22,8 +23,15 @@ class AccountInvoiceLine(models.Model):
                 factor =\
                     self.uos_id.factor_inv\
                     / self.product_id.uom_id.factor_inv
-            line_shared_cost = self.invoice_id.distributed_expense_total * (
-                self.price_subtotal / self.invoice_id.product_expense_total)
+            if self.invoice_id.product_expense_total != 0:
+                line_shared_cost =\
+                    self.invoice_id.distributed_expense_total * (
+                        self.price_subtotal /
+                        self.invoice_id.product_expense_total)
+            else:
+                raise UserError(_(
+                    "We can't check prices"
+                    " for a invoice whose total is null"))
             return (
                 line_shared_cost / self.quantity + (
                     self.price_unit *


### PR DESCRIPTION
Quand on fait "Verifier les infos fournisseurs", il y a une erreur si le PU d'un produit est nul :+1: 
Catche l'erreur quand le sous-total d'une ligne est nulle.

![Peek 15-03-2019 11-25](https://user-images.githubusercontent.com/9005817/54425280-37f1f580-4715-11e9-8954-989b889dc135.gif)

