### PR TITLE
 [FIX] account_invoice_supplierinfo_update_standard_price: divide per…

### DIFF
--- a/account_invoice_supplierinfo_update_standard_price/i18n/fr.po
+++ b/account_invoice_supplierinfo_update_standard_price/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-18 11:11+0000\n"
-"PO-Revision-Date: 2020-09-18 11:11+0000\n"
+"POT-Creation-Date: 2020-12-17 16:32+0000\n"
+"PO-Revision-Date: 2020-12-17 16:32+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -52,7 +52,7 @@ msgstr "Ligne de facture"
 #. module: account_invoice_supplierinfo_update_standard_price
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_standard_price.field_wizard_update_invoice_supplierinfo_line__new_standard_price
 msgid "New Standard Price"
-msgstr "Nouveau Prix de revient"
+msgstr "Nouveau prix de revient"
 
 #. module: account_invoice_supplierinfo_update_standard_price
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_standard_price.field_account_invoice__product_expense_total
@@ -65,7 +65,7 @@ msgid "Product Template"
 msgstr "Modèle d'article"
 
 #. module: account_invoice_supplierinfo_update_standard_price
-#: code:addons/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py:25
+#: code:addons/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py:26
 #, python-format
 msgid "We can't check prices for a invoice whose total is null"
 msgstr "On ne peut pas vérifier les prix pour une facture nulle."
@@ -73,7 +73,7 @@ msgstr "On ne peut pas vérifier les prix pour une facture nulle."
 #. module: account_invoice_supplierinfo_update_standard_price
 #: model:ir.model,name:account_invoice_supplierinfo_update_standard_price.model_wizard_update_invoice_supplierinfo_line
 msgid "Wizard Line to update supplierinfo"
-msgstr "Line d'assistant de mise à jour des informations fournisseurs"
+msgstr "Line d'assistant pour mettre à jour les informations fournisseurs"
 
 #. module: account_invoice_supplierinfo_update_standard_price
 #: model:ir.model,name:account_invoice_supplierinfo_update_standard_price.model_wizard_update_invoice_supplierinfo

--- a/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py
@@ -25,10 +25,14 @@ class AccountInvoiceLine(models.Model):
                 raise UserError(_(
                     "We can't check prices"
                     " for a invoice whose total is null"))
+            if self.quantity:
+                line_shared_cost_per_unit = line_shared_cost / self.quantity
+            else:
+                line_shared_cost_per_unit = 0
             uom = self.uom_id or self.product_id.uom_id
             return self.invoice_id.currency_id.round(
                 uom._compute_price(
-                    line_shared_cost + (
+                    line_shared_cost_per_unit + (
                         self.price_unit *
                         (1 - self.discount / 100) *
                         (1 - self.discount2 / 100) *

--- a/account_invoice_supplierinfo_update_standard_price/tests/test_module.py
+++ b/account_invoice_supplierinfo_update_standard_price/tests/test_module.py
@@ -93,7 +93,7 @@ class TestModule(TransactionCase):
     def test_03_shared_cost(self):
         self.assertEqual(
             self.invoice_1.product_expense_total,
-            (1000 * 10 * 0.9 * 0.8 * 0.7) + 500 * 5,
+            7540,  # (1000 * 10 * 0.9 * 0.8 * 0.7) + 500 * 5,
             "Bad computation of the field 'Product Expenses Total'")
 
         self.assertEqual(
@@ -122,13 +122,13 @@ class TestModule(TransactionCase):
         # Check Correct Standard Price
         self.assertEqual(
             round(self.line_1_1.product_id.standard_price, 2),
-            1172.44,  # (5040 / 10) + 1000 * (5040 / 7540)
+            570.84,  # (5040 + 1000 * (5040 / 7540)) / 10
             "Landing cost should impact standard price of the purchased"
             " product")
 
         # Check Correct Standard Price
         self.assertEqual(
             round(self.line_1_2.product_id.standard_price, 2),
-            831.56,  # (500) + 1000 * (2500 / 7540)
+            566.31,  # (2500 + 1000 * (2500 / 7540)) / 5
             "Landing cost should impact standard price of the purchased"
             " product")


### PR DESCRIPTION
… quantity to compute shared cost

#/board/144/card/1178

CC : @quentinDupont 


Ref : in V8 : https://github.com/grap/grap-odoo-business/blob/8.0/account_invoice_supplierinfo_update_standard_price/models/account_invoice_line.py#L36