### PR TITLE
 [IMP] technical_partner_access : indexes and _name_search improvments

### DIFF
--- a/technical_partner_access/__manifest__.py
+++ b/technical_partner_access/__manifest__.py
@@ -13,6 +13,7 @@
     "license": "AGPL-3",
     "depends": [
         "base",
+        "name_search_reset_res_partner",
     ],
     "data": [
         "views/view_res_partner.xml",

--- a/technical_partner_access/models/res_partner.py
+++ b/technical_partner_access/models/res_partner.py
@@ -11,10 +11,16 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     is_odoo_user = fields.Boolean(
-        string="Is an Odoo User", readonly=True, default=False
+        string="Is an Odoo User",
+        readonly=True,
+        default=False,
+        index=True,
     )
     is_odoo_company = fields.Boolean(
-        string="Is an Odoo Company", readonly=True, default=False
+        string="Is an Odoo Company",
+        readonly=True,
+        default=False,
+        index=True,
     )
 
     @api.model
@@ -87,28 +93,4 @@ class ResPartner(models.Model):
             order=order,
             count=count,
             access_rights_uid=access_rights_uid,
-        )
-
-    @api.model
-    def _name_search(
-        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
-    ):
-        # Overload also _name_search
-        # because res.partner._name_search doesn't call super in all
-        # cases. (so doesn't call _search)
-        if name and operator in ("=", "ilike", "=ilike", "like", "=like"):
-            args += [
-                (
-                    "is_odoo_user",
-                    "=",
-                    bool(self.env.context.get("show_odoo_user", False)),
-                ),
-                (
-                    "is_odoo_company",
-                    "=",
-                    bool(self.env.context.get("show_odoo_company", False)),
-                ),
-            ]
-        return super()._name_search(
-            name, args, operator=operator, limit=limit, name_get_uid=name_get_uid
         )

--- a/technical_partner_access/tests/test_module.py
+++ b/technical_partner_access/tests/test_module.py
@@ -33,7 +33,7 @@ class TestModule(TransactionCase):
             "User's partner should not have company.",
         )
 
-        # Check access without context
+        # Check access without context (by search)
         result = self.ResPartner.search([("name", "=", self.user_name)])
         self.assertEqual(
             len(result),
@@ -41,12 +41,28 @@ class TestModule(TransactionCase):
             "Search user partner should not return result without context",
         )
 
-        # Check access with context
+        # Check access without context (by name_search)
+        result = self.ResPartner.name_search(self.user_name)
+        self.assertEqual(
+            len(result),
+            0,
+            "Name Search user partner should not return result without context",
+        )
+
+        # Check access with context (by search)
         result = self.ResPartner.with_context(show_odoo_user=True).search(
             [("name", "=", self.user_name)]
         )
         self.assertEqual(
             len(result), 1, "Search user partner should return result with context"
+        )
+
+        # Check access with context (by name_search)
+        result = self.ResPartner.with_context(show_odoo_user=True).name_search(
+            self.user_name
+        )
+        self.assertEqual(
+            len(result), 1, "Name Search user partner should return result with context"
         )
 
         # Without Correct access right, should fail
@@ -70,20 +86,36 @@ class TestModule(TransactionCase):
                 "name": self.company_name,
             }
         )
-        # Check access without context
+        # Check access without context (by search)
         result = self.ResPartner.search([("name", "=", self.company_name)])
         self.assertEqual(
             len(result),
             0,
             "Search company partner should not return result without context",
         )
+        # Check access without context (by name_search)
+        result = self.ResPartner.name_search(self.company_name)
+        self.assertEqual(
+            len(result),
+            0,
+            "Name Search company partner should not return result without context",
+        )
 
-        # Check access with context
+        # Check access with context (by search)
         result = self.ResPartner.with_context(show_odoo_company=True).search(
             [("name", "=", self.company_name)]
         )
         self.assertEqual(
             len(result), 1, "Search company partner should return result with context"
+        )
+        # Check access with context (by name_search)
+        result = self.ResPartner.with_context(show_odoo_company=True).name_search(
+            self.company_name
+        )
+        self.assertEqual(
+            len(result),
+            1,
+            "Name Search company partner should return result with context",
         )
 
         # Without Correct access right, should fail


### PR DESCRIPTION
add indexes on is_odoo_user and is_odoo_company fields ; 
[IMP] remove overload of _name_search and instead, add a dependency to new module name_search_reset_res_partner

requete

```
EXPLAIN ANALYZE SELECT count(1) FROM "res_partner" WHERE (((((((("res_partner"."active" = true)  AND  ((("res_partner"."display_name"::text ilike '%a%')  OR  ("res_partner"."ref" = 'a'))  OR  ("res_partner"."email"::text ilike '%a%')))  AND  ("res_partner"."is_odoo_user" IS NULL or "res_partner"."is_odoo_user" = false ))  AND  ("res_partner"."is_odoo_company" IS NULL or "res_partner"."is_odoo_company" = false ))  AND  ("res_partner"."is_joint_buying" IS NULL or "res_partner"."is_joint_buying" = false ))  AND  ("res_partner"."is_odoo_user" IS NULL or "res_partner"."is_odoo_user" = false ))  AND  ("res_partner"."is_odoo_company" IS NULL or "res_partner"."is_odoo_company" = false ))  AND  ("res_partner"."is_joint_buying" IS NULL or "res_partner"."is_joint_buying" = false )) AND ((((((("res_partner"."company_id" = 81)  OR  ("res_partner"."company_id" = 81))  OR  ("res_partner"."company_id" in (81)))  OR  "res_partner"."company_id" IS NULL )  OR  ("res_partner"."is_odoo_user" = true))  OR  ("res_partner"."is_odoo_company" = true))  AND  (("res_partner"."type" != 'private')  OR  "res_partner"."type" IS NULL ));
```

```
current prod : 

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=4.75..4.76 rows=1 width=8) (actual time=0.086..0.087 rows=1 loops=1)
   ->  Seq Scan on res_partner  (cost=0.00..4.74 rows=3 width=0) (actual time=0.083..0.084 rows=0 loops=1)
         Filter: (active AND ((is_odoo_user IS NULL) OR (NOT is_odoo_user)) AND ((is_odoo_company IS NULL) OR (NOT is_odoo_company)) AND ((is_joint_buying IS NULL) OR (NOT is_joint_buying)) AND ((is_odoo_user IS NULL) OR (NOT is_odoo_user)) AND ((is_odoo_company IS NULL) OR (NOT is_odoo_company)) AND ((is_joint_buying IS NULL) OR (NOT is_joint_buying)) AND (((type)::text <> 'private'::text) OR (type IS NULL)) AND (((display_name)::text ~~* '%a%'::text) OR ((ref)::text = 'a'::text) OR ((email)::text ~~* '%a%'::text)) AND ((company_id = 81) OR (company_id = 81) OR (company_id = 81) OR (company_id IS NULL) OR is_odoo_user OR is_odoo_company))
         Rows Removed by Filter: 28
 Planning time: 0.469 ms
 Execution time: 0.163 ms
```
