### PR TITLE
[FIX] product_print_category_food_report : bad translation for qweb_t…

### DIFF
--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -55,7 +55,7 @@ msgstr "<span class=\"empty_field\"><b>Producteur·rice</b></span><br/>"
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_bulk_long
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_bulk_square
 msgid "<span class=\"empty_field\"><b>Origin</b></span><br/>"
-msgstr "span class=\"empty_field\"><b>Origine</b></span><br/>"
+msgstr "<span class=\"empty_field\"><b>Origine</b></span><br/>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_counter


### PR DESCRIPTION



Une seule lettre vous manque, et l'étiquette est repeuplée.


![image](https://user-images.githubusercontent.com/3407482/121173425-1979f680-c859-11eb-9939-063c046677a6.png)


CC : @quentinDupont 