### PR TITLE
 [FIX] account_move_change_number : correctly change number also for refund. (without that patch a VTAV/ is renamed into VT/

### DIFF
--- a/account_move_change_number/models/account_move.py
+++ b/account_move_change_number/models/account_move.py
@@ -23,9 +23,7 @@ class AccountMove(models.Model):
             move.name = "/"
 
             # Get related invoice
-            invoices = self.env["account.invoice"].search(
-                [('move_id', "=", move.id)]
-            )
+            invoices = self.env["account.invoice"].search([("move_id", "=", move.id)])
             if invoices:
                 invoice = invoices[0]
                 invoice.move_name = "/"

--- a/account_move_change_number/models/account_move.py
+++ b/account_move_change_number/models/account_move.py
@@ -22,8 +22,18 @@ class AccountMove(models.Model):
             # set name to "/"
             move.name = "/"
 
+            # Get related invoice
+            invoices = self.env["account.invoice"].search(
+                [('move_id', "=", move.id)]
+            )
+            if invoices:
+                invoice = invoices[0]
+                invoice.move_name = "/"
+            else:
+                invoice = False
+
             # post account move
-            move.post()
+            move.post(invoice=invoice)
             new_name = move.name
 
             # Add description of the change

--- a/recurring_consignment_test/tests/test_recurring_consignment.py
+++ b/recurring_consignment_test/tests/test_recurring_consignment.py
@@ -145,9 +145,12 @@ class TestRecurringConsignment(TransactionCase):
 
         # Set max date to the last day of the current month
         today = fields.date.today()
-        wizard.max_date = fields.date(today.year, today.month + 1, 1) - timedelta(
-            days=1
-        )
+        if today.month < 12:
+            wizard.max_date = fields.date(today.year, today.month + 1, 1) - timedelta(
+                days=1
+            )
+        else:
+            wizard.max_date = fields.date(today.year + 1, 1, 1) - timedelta(days=1)
 
         wizard._onchange_max_date()
 


### PR DESCRIPTION
Note : 

ce patch a déjà été passé en prod le 18/11/2021 comme un petit cochon pour pouvoir renuméroter la compta de DTB. (demandé par Sibylle)

a passer vraiment en prod.