### PR TITLE
[12.0][IMP] product_print_category_food_report Some improvements after big upgrade

### DIFF
--- a/product_print_category_food_report/__manifest__.py
+++ b/product_print_category_food_report/__manifest__.py
@@ -40,6 +40,7 @@
         "report/qweb_template_pricetag_31.xml",
         "report/qweb_template_pricetag_32.xml",
         "report/qweb_template_pricetag_33.xml",
+        "report/qweb_template_pricetag_40.xml",
         "views/view_res_company.xml",
         "views/view_product_pricetag_type.xml",
         "views/view_product_product.xml",

--- a/product_print_category_food_report/__manifest__.py
+++ b/product_print_category_food_report/__manifest__.py
@@ -39,6 +39,7 @@
         "report/qweb_template_pricetag_30.xml",
         "report/qweb_template_pricetag_31.xml",
         "report/qweb_template_pricetag_32.xml",
+        "report/qweb_template_pricetag_33.xml",
         "views/view_res_company.xml",
         "views/view_product_pricetag_type.xml",
         "views/view_product_product.xml",

--- a/product_print_category_food_report/data/product_print_category.xml
+++ b/product_print_category_food_report/data/product_print_category.xml
@@ -58,6 +58,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="qweb_view_id" ref="qweb_template_pricetag_33" />
     </record>
 
+    <record id="print_category_pricetag_40" model="product.print.category">
+        <field name="name">Shelf Small Size - Packaged Products (no label, no barcode) - 61x24 (N°40)</field>
+        <field name="qweb_view_id" ref="qweb_template_pricetag_40" />
+    </record>
+
     <function model="product.print.category" name="write">
         <value model="product.print.category" eval="[
             ref('product_print_category_food_report.print_category_pricetag_01'),
@@ -70,6 +75,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             ref('product_print_category_food_report.print_category_pricetag_31'),
             ref('product_print_category_food_report.print_category_pricetag_32'),
             ref('product_print_category_food_report.print_category_pricetag_33'),
+            ref('product_print_category_food_report.print_category_pricetag_40'),
             ]"
         />
         <value eval="{
@@ -98,6 +104,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             ref('product_print_category_food_report.print_category_pricetag_31'),
             ref('product_print_category_food_report.print_category_pricetag_32'),
             ref('product_print_category_food_report.print_category_pricetag_33'),
+            ref('product_print_category_food_report.print_category_pricetag_40'),
             ]"
         />
         <value eval="{

--- a/product_print_category_food_report/data/product_print_category.xml
+++ b/product_print_category_food_report/data/product_print_category.xml
@@ -54,6 +54,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="qweb_view_id" ref="qweb_template_pricetag_32" />
     </record>
 
+    <record id="print_category_pricetag_33" model="product.print.category">
+        <field name="name">Bulk - 68x68mm (N°33)</field>
+        <field name="qweb_view_id" ref="qweb_template_pricetag_33" />
+    </record>
+
     <function model="product.print.category" name="write">
         <value model="product.print.category" eval="[
             ref('product_print_category_food_report.print_category_pricetag_01'),
@@ -65,6 +70,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             ref('product_print_category_food_report.print_category_pricetag_30'),
             ref('product_print_category_food_report.print_category_pricetag_31'),
             ref('product_print_category_food_report.print_category_pricetag_32'),
+            ref('product_print_category_food_report.print_category_pricetag_33'),
             ]"
         />
         <value eval="{
@@ -92,6 +98,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             ref('product_print_category_food_report.print_category_pricetag_30'),
             ref('product_print_category_food_report.print_category_pricetag_31'),
             ref('product_print_category_food_report.print_category_pricetag_32'),
+            ref('product_print_category_food_report.print_category_pricetag_33'),
             ]"
         />
         <value eval="{
@@ -113,6 +120,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             ref('product_print_category_food_report.print_category_pricetag_30'),
             ref('product_print_category_food_report.print_category_pricetag_31'),
             ref('product_print_category_food_report.print_category_pricetag_32'),
+            ref('product_print_category_food_report.print_category_pricetag_33'),
             ]"
         />
         <value eval="{

--- a/product_print_category_food_report/data/product_print_category.xml
+++ b/product_print_category_food_report/data/product_print_category.xml
@@ -18,29 +18,28 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
     </record>
 
     <record id="print_category_pricetag_10" model="product.print.category">
-        <field name="name">Shelf Rectangular - 79x32mm  (N°10)</field>
+        <field name="name">Shelf Rectangular - 79x32mm (N°10)</field>
         <field name="qweb_view_id" ref="qweb_template_pricetag_10" />
     </record>
 
 
     <record id="print_category_pricetag_11" model="product.print.category">
-        <field name="name">Shelf Rectangular Litle Margin - 79x37mm  (N°11)</field>
+        <field name="name">Shelf Rectangular Litle Margin - 79x37mm (N°11)</field>
         <field name="qweb_view_id" ref="qweb_template_pricetag_11" />
-
     </record>
 
     <record id="print_category_pricetag_12" model="product.print.category">
-        <field name="name">Shelf Rectangular Middle Margin - 79x44mm  (N°12)</field>
+        <field name="name">Shelf Rectangular Middle Margin - 79x44mm (N°12)</field>
         <field name="qweb_view_id" ref="qweb_template_pricetag_12" />
     </record>
 
     <record id="print_category_pricetag_20" model="product.print.category">
-        <field name="name">Counter - 97x58mm  (N°20)</field>
+        <field name="name">Counter - 97x58mm (N°20)</field>
         <field name="qweb_view_id" ref="qweb_template_pricetag_20" />
     </record>
 
     <record id="print_category_pricetag_30" model="product.print.category">
-        <field name="name">Bulk - 54x105mm Applymage  (N°30)</field>
+        <field name="name">Bulk - 54x105mm Applymage (N°30)</field>
         <field name="qweb_view_id" ref="qweb_template_pricetag_30" />
     </record>
 

--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-12 15:16+0000\n"
-"PO-Revision-Date: 2024-07-12 15:16+0000\n"
+"POT-Creation-Date: 2024-07-23 14:16+0000\n"
+"PO-Revision-Date: 2024-07-23 14:16+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -381,8 +381,9 @@ msgstr "Etagère - 79x43mm Rectangulaire marge moyenne (N°12)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_13
-msgid "Shelf Rectangular Small Size (no label, no barcode) - 61x24 (N°13)"
-msgstr "Etagère - 61x24mm Rectangulaire (pas de label ni code-barre) (N°13)"
+#: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_40
+msgid "Shelf Small Size - Packaged Products (no label, no barcode) - 61x24 (N°40)"
+msgstr "Etagère Petite taille - Produits emballés (pas de label, pas de code-barre) - 61x24 (N°40)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_01

--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-04 07:19+0000\n"
-"PO-Revision-Date: 2024-07-04 07:19+0000\n"
+"POT-Creation-Date: 2024-07-05 13:55+0000\n"
+"PO-Revision-Date: 2024-07-05 13:55+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -62,37 +62,37 @@ msgstr ""
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
 msgid "<span class=\"info_title\">Allergens:</span>"
-msgstr "<span class=\"info_title\">Allergènes : </span>"
+msgstr "<span class=\"info_title\">Allergènes :</span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
 msgid "<span class=\"info_title\">Ingredients:</span>"
-msgstr "<span class=\"info_title\">Ingrédients : </span>"
+msgstr "<span class=\"info_title\">Ingrédients :</span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
 msgid "<span class=\"info_title\">Manufacturing: </span>"
-msgstr "<span class=\"info_title\">Fabrication : </span>"
+msgstr "<span class=\"info_title\">Fabrication :</span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
 msgid "<span class=\"info_title\">Manufacturing:</span>"
-msgstr "<span class=\"info_title\">Fabrication : </span>"
+msgstr "<span class=\"info_title\">Fabrication :</span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
 msgid "<span class=\"info_title\">Producer: </span>"
-msgstr "<span class=\"info_title\">Fabricant·e : </span>"
+msgstr "<span class=\"info_title\">Fabricant·e :</span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
 msgid "<span class=\"info_title\">Producer:</span>"
-msgstr "<span class=\"info_title\">Fabricant·e : </span>"
+msgstr "<span class=\"info_title\">Fabricant·e :</span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
 msgid "<span class=\"info_title\">Traces:</span>"
-msgstr "<span class=\"info_title\">Traces : </span>"
+msgstr "<span class=\"info_title\">Traces :</span>"
 
 #. module: product_print_category_food_report
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_product__allergen_text
@@ -108,6 +108,11 @@ msgstr "Disponible pour les étiquettes"
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_30
 msgid "Bulk - 54x105mm Applymage  (N°30)"
 msgstr "Vrac - 54x105mm Applymage  (N°30)"
+
+#. module: product_print_category_food_report
+#: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_33
+msgid "Bulk - 68x68mm (N°33)"
+msgstr "Vrac - 68x68mm (N°33)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_31

--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-05 13:55+0000\n"
-"PO-Revision-Date: 2024-07-05 13:55+0000\n"
+"POT-Creation-Date: 2024-07-12 15:16+0000\n"
+"PO-Revision-Date: 2024-07-12 15:16+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -378,6 +378,11 @@ msgstr "Etagère - 79x37mm Rectangulaire marge petite (N°11)"
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_12
 msgid "Shelf Rectangular Middle Margin - 79x44mm (N°12)"
 msgstr "Etagère - 79x43mm Rectangulaire marge moyenne (N°12)"
+
+#. module: product_print_category_food_report
+#: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_13
+msgid "Shelf Rectangular Small Size (no label, no barcode) - 61x24 (N°13)"
+msgstr "Etagère - 61x24mm Rectangulaire (pas de label ni code-barre) (N°13)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_01

--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -106,8 +106,8 @@ msgstr "Disponible pour les étiquettes"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_30
-msgid "Bulk - 54x105mm Applymage  (N°30)"
-msgstr "Vrac - 54x105mm Applymage  (N°30)"
+msgid "Bulk - 54x105mm Applymage (N°30)"
+msgstr "Vrac - 54x105mm Applymage (N°30)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_33
@@ -152,8 +152,8 @@ msgstr "Société"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_20
-msgid "Counter - 97x58mm  (N°20)"
-msgstr "Comptoir - 97x58mm  (N°20)"
+msgid "Counter - 97x58mm (N°20)"
+msgstr "Comptoir - 97x58mm (N°20)"
 
 #. module: product_print_category_food_report
 #: model:ir.model,name:product_print_category_food_report.model_res_country_group
@@ -366,17 +366,17 @@ msgstr "Définir une unité de mesure alternative si vous voulez afficher un pri
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_10
-msgid "Shelf Rectangular - 79x32mm  (N°10)"
+msgid "Shelf Rectangular - 79x32mm (N°10)"
 msgstr "Etagère - 79x32mm Rectangulaire (N°10)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_11
-msgid "Shelf Rectangular Litle Margin - 79x37mm  (N°11)"
+msgid "Shelf Rectangular Litle Margin - 79x37mm (N°11)"
 msgstr "Etagère - 79x37mm Rectangulaire marge petite (N°11)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_12
-msgid "Shelf Rectangular Middle Margin - 79x44mm  (N°12)"
+msgid "Shelf Rectangular Middle Margin - 79x44mm (N°12)"
 msgstr "Etagère - 79x43mm Rectangulaire marge moyenne (N°12)"
 
 #. module: product_print_category_food_report

--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -72,7 +72,7 @@ msgstr "<span class=\"info_title\">Ingrédients :</span>"
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
 msgid "<span class=\"info_title\">Manufacturing: </span>"
-msgstr "<span class=\"info_title\">Fabrication :</span>"
+msgstr "<span class=\"info_title\">Fabrication : </span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
@@ -82,7 +82,7 @@ msgstr "<span class=\"info_title\">Fabrication :</span>"
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
 msgid "<span class=\"info_title\">Producer: </span>"
-msgstr "<span class=\"info_title\">Fabricant·e :</span>"
+msgstr "<span class=\"info_title\">Fabricant·e : </span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
@@ -383,7 +383,7 @@ msgstr "Etagère - 79x43mm Rectangulaire marge moyenne (N°12)"
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_13
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_40
 msgid "Shelf Small Size - Packaged Products (no label, no barcode) - 61x24 (N°40)"
-msgstr "Etagère Petite taille - Produits emballés (pas de label, pas de code-barre) - 61x24 (N°40)"
+msgstr "Etagère - 61x24mm Produits emballés (pas de label, pas de code-barre) (N°40)"
 
 #. module: product_print_category_food_report
 #: model:product.print.category,name:product_print_category_food_report.print_category_pricetag_01

--- a/product_print_category_food_report/i18n/fr.po
+++ b/product_print_category_food_report/i18n/fr.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#   * product_print_category_food_report
+#	* product_print_category_food_report
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-24 09:20+0000\n"
-"PO-Revision-Date: 2024-05-24 09:20+0000\n"
+"POT-Creation-Date: 2024-07-04 07:19+0000\n"
+"PO-Revision-Date: 2024-07-04 07:19+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,79 +16,82 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:166
-#: code:addons/product_print_category_food_report/models/product_product.py:195
-#: code:addons/product_print_category_food_report/models/product_product.py:201
+#: code:addons/product_print_category_food_report/models/product_product.py:155
+#: code:addons/product_print_category_food_report/models/product_product.py:184
+#: code:addons/product_print_category_food_report/models/product_product.py:190
 #, python-format
 msgid " per kilo"
 msgstr "le kilo"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:205
+#: code:addons/product_print_category_food_report/models/product_product.py:194
 #, python-format
 msgid " per liter"
 msgstr "le litre"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:193
+#: code:addons/product_print_category_food_report/models/product_product.py:182
 #, python-format
 msgid " per piece"
 msgstr "la pièce"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:228
+#: code:addons/product_print_category_food_report/models/product_product.py:217
 #, python-format
 msgid "%.0f gr"
 msgstr ""
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:238
+#: code:addons/product_print_category_food_report/models/product_product.py:227
 #, python-format
 msgid "%.0f mL"
 msgstr ""
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:235
+#: code:addons/product_print_category_food_report/models/product_product.py:224
 #, python-format
 msgid "%.3f L"
 msgstr ""
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:225
+#: code:addons/product_print_category_food_report/models/product_product.py:214
 #, python-format
 msgid "%.3f kg"
 msgstr ""
 
 #. module: product_print_category_food_report
-#: model:uom.uom,name:product_print_category_food_report.uom_100_gr
-msgid "100 gr"
-msgstr ""
-
-#. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
-msgid "<span class=\"info_title\">Allergens: </span>"
+msgid "<span class=\"info_title\">Allergens:</span>"
 msgstr "<span class=\"info_title\">Allergènes : </span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
-msgid "<span class=\"info_title\">Ingredients: </span>"
+msgid "<span class=\"info_title\">Ingredients:</span>"
 msgstr "<span class=\"info_title\">Ingrédients : </span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
-#: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
 msgid "<span class=\"info_title\">Manufacturing: </span>"
 msgstr "<span class=\"info_title\">Fabrication : </span>"
 
 #. module: product_print_category_food_report
-#: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
+msgid "<span class=\"info_title\">Manufacturing:</span>"
+msgstr "<span class=\"info_title\">Fabrication : </span>"
+
+#. module: product_print_category_food_report
+#: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_B
 msgid "<span class=\"info_title\">Producer: </span>"
 msgstr "<span class=\"info_title\">Fabricant·e : </span>"
 
 #. module: product_print_category_food_report
 #: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
-msgid "<span class=\"info_title\">Traces: </span>"
+msgid "<span class=\"info_title\">Producer:</span>"
+msgstr "<span class=\"info_title\">Fabricant·e : </span>"
+
+#. module: product_print_category_food_report
+#: model_terms:ir.ui.view,arch_db:product_print_category_food_report.qweb_template_pricetag_template_C
+msgid "<span class=\"info_title\">Traces:</span>"
 msgstr "<span class=\"info_title\">Traces : </span>"
 
 #. module: product_print_category_food_report
@@ -148,6 +151,11 @@ msgid "Counter - 97x58mm  (N°20)"
 msgstr "Comptoir - 97x58mm  (N°20)"
 
 #. module: product_print_category_food_report
+#: model:ir.model,name:product_print_category_food_report.model_res_country_group
+msgid "Country Group"
+msgstr "Groupe de pays"
+
+#. module: product_print_category_food_report
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_pricetag_type__create_uid
 msgid "Created by"
 msgstr "Créé par"
@@ -193,12 +201,12 @@ msgstr "Dernière modification le"
 #. module: product_print_category_food_report
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_pricetag_type__write_uid
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr "Mis à jour par"
 
 #. module: product_print_category_food_report
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_pricetag_type__write_date
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr "Mis à jour le"
 
 #. module: product_print_category_food_report
 #: code:addons/product_print_category_food_report/models/product_product.py:57
@@ -212,13 +220,13 @@ msgid "Name"
 msgstr "Nom"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:232
+#: code:addons/product_print_category_food_report/models/product_product.py:221
 #, python-format
 msgid "Net Volume"
 msgstr "Volume Net"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:222
+#: code:addons/product_print_category_food_report/models/product_product.py:211
 #, python-format
 msgid "Net Weight"
 msgstr "Poids Net"
@@ -251,60 +259,6 @@ msgstr "Origine des ingrédients: %s. "
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_product__pricetag_origin
 msgid "Origin on pricetag"
 msgstr "Origine - rendu final sur l'étiquette"
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_01
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_01_product_template
-msgid "Pricetag 01 - Abricot de Turquie moelleux 250gr"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_02
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_02_product_template
-msgid "Pricetag 02 - Acérola - 30comprimés 84gr"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_10
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_10_product_template
-msgid "Pricetag 10 - Acha Peu Gingembre 33cl"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_11
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_11_product_template
-msgid "Pricetag 11 - Abricot Le jardinier glacier (550mL)"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_12
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_12_product_template
-msgid "Pricetag 12 - Antisèche blonde (75cl)"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_20
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_20_product_template
-msgid "Pricetag 20 - Nem végétarien vrac (unité)"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_30
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_30_product_template
-msgid "Pricetag 30 - Amande au Caramel et Chocolat"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_31
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_31_product_template
-msgid "Pricetag 31 - Biscuits Cookies noisettes chocolat"
-msgstr ""
-
-#. module: product_print_category_food_report
-#: model:product.product,name:product_print_category_food_report.product_with_pricetag_32
-#: model:product.template,name:product_print_category_food_report.product_with_pricetag_32_product_template
-msgid "Pricetag 32 - Caramel au beurre salé en VRAC"
-msgstr ""
 
 #. module: product_print_category_food_report
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_product__pricetag_color
@@ -398,7 +352,7 @@ msgstr "Articles"
 #. module: product_print_category_food_report
 #: model:ir.model.fields,field_description:product_print_category_food_report.field_product_pricetag_type__product_qty
 msgid "Products Quantity"
-msgstr "Nombre d'articles"
+msgstr ""
 
 #. module: product_print_category_food_report
 #: model:ir.model.fields,help:product_print_category_food_report.field_product_product__pricetag_uom_id
@@ -436,57 +390,12 @@ msgid "Trace Allergen Text"
 msgstr "Texte de traces d'allergènes"
 
 #. module: product_print_category_food_report
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_01
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_02
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_10
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_11
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_12
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_20
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_01_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_02_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_10_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_11_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_12_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_20_product_template
-msgid "Unit(s)"
-msgstr "Unité(s)"
-
-#. module: product_print_category_food_report
 #: model:ir.model.fields,help:product_print_category_food_report.field_uom_uom__pricetag_name
 msgid "Used alternatively to the name field, on labels for displaying secondary unit prices"
 msgstr "Utilisé de façon alternative au champ nom, sur les étiquettes, pour afficher les prix aux unités secondaires"
 
 #. module: product_print_category_food_report
-#: code:addons/product_print_category_food_report/models/product_product.py:160
+#: code:addons/product_print_category_food_report/models/product_product.py:149
 #, python-format
 msgid "for %s"
 msgstr "Pour %s"
-
-#. module: product_print_category_food_report
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_30
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_31
-#: model:product.product,uom_name:product_print_category_food_report.product_with_pricetag_32
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_01
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_02
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_10
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_11
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_12
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_20
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_30
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_31
-#: model:product.product,weight_uom_name:product_print_category_food_report.product_with_pricetag_32
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_30_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_31_product_template
-#: model:product.template,uom_name:product_print_category_food_report.product_with_pricetag_32_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_01_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_02_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_10_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_11_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_12_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_20_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_30_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_31_product_template
-#: model:product.template,weight_uom_name:product_print_category_food_report.product_with_pricetag_32_product_template
-msgid "kg"
-msgstr ""
-

--- a/product_print_category_food_report/report/qweb_components.xml
+++ b/product_print_category_food_report/report/qweb_components.xml
@@ -14,7 +14,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <img t-elif="len(line.product_id.barcode) == 8"
                     t-att-src="'/report/barcode/?humanreadable=1&amp;type=EAN8&amp;value=%s' % (line.product_id.barcode)"/>
                 <img t-else=""
-                    t-att-src="'/report/barcode/?humanreadable=1&amp;?type=Code128&amp;value=%s' % (line.product_id.barcode)"/>
+                    t-att-src="'/report/barcode/?humanreadable=1&amp;type=Code128&amp;value=%s' % (line.product_id.barcode)"/>
             </t>
         </div>
     </template>

--- a/product_print_category_food_report/report/qweb_reports.xml
+++ b/product_print_category_food_report/report/qweb_reports.xml
@@ -29,7 +29,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_33.scss" />
 
             <!-- Uncomment the following line to debug -->
-<!--             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/debug.scss" /> -->
+            <!-- <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/debug.scss" /> -->
 
         </xpath>
     </template>

--- a/product_print_category_food_report/report/qweb_reports.xml
+++ b/product_print_category_food_report/report/qweb_reports.xml
@@ -26,6 +26,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_30.scss" />
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_31.scss" />
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_32.scss" />
+            <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_33.scss" />
 
             <!-- Uncomment the following line to debug -->
 <!--             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/debug.scss" /> -->

--- a/product_print_category_food_report/report/qweb_reports.xml
+++ b/product_print_category_food_report/report/qweb_reports.xml
@@ -27,6 +27,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_31.scss" />
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_32.scss" />
             <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_33.scss" />
+            <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/pricetag_40.scss" />
 
             <!-- Uncomment the following line to debug -->
             <!-- <link rel="stylesheet" type="text/scss" href="/product_print_category_food_report/static/src/scss/debug.scss" /> -->

--- a/product_print_category_food_report/report/qweb_template_pricetag_33.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_33.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+@author: Quentin DUPONT (https://twitter.com/pondupont)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <template id="qweb_template_pricetag_33">
+        <t t-set="pricetag_name" t-value="'pricetag_33'"/>
+        <t t-call="product_print_category_food_report.qweb_template_pricetag_template_C" />
+    </template>
+
+</odoo>

--- a/product_print_category_food_report/report/qweb_template_pricetag_33.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_33.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
-@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 @author: Quentin DUPONT (https://twitter.com/pondupont)
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->

--- a/product_print_category_food_report/report/qweb_template_pricetag_40.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_40.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2024 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+@author: Quentin DUPONT (https://twitter.com/pondupont)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <template id="qweb_template_pricetag_40">
+        <t t-set="pricetag_name" t-value="'pricetag_40'"/>
+        <t t-call="product_print_category_food_report.qweb_template_pricetag_template_B" />
+    </template>
+
+</odoo>

--- a/product_print_category_food_report/report/qweb_template_pricetag_template_A.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_template_A.xml
@@ -12,6 +12,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <t t-foreach="category_data['lines']" t-as="line">
                 <t t-foreach="line.quantity" t-as="q">
                     <div t-att-class="'pricetag_product %s' % pricetag_name">
+                        <div class="margin_top" />
 
                         <!-- Product name -->
                         <div class="product_name"
@@ -59,6 +60,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             <t t-esc="line.product_id.pricetag_print_date_text" />
                         </div>
 
+                        <!-- Margin -->
+                        <div class="margin_bottom" />
                     </div>
                 </t>
             </t>

--- a/product_print_category_food_report/report/qweb_template_pricetag_template_C.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_template_C.xml
@@ -27,24 +27,24 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
                                 <!-- Manufacturing Location -->
                                 <div class="product_origin" t-if="line.product_id.pricetag_origin">
-                                    <span class="info_title">Manufacturing: </span><t t-esc="line.product_id.pricetag_origin"/>
+                                    <span class="info_title">Manufacturing:</span>&#160;<t t-esc="line.product_id.pricetag_origin"/>
                                 </div>
 
                                 <!-- Producer -->
                                 <div class="maker_description"  t-if="line.product_id.maker_description">
-                                    <span class="info_title">Producer: </span><t t-esc="line.product_id.maker_description"/>
+                                    <span class="info_title">Producer:</span>&#160;<t t-esc="line.product_id.maker_description"/>
                                 </div>
 
                                 <!-- Feed Composition (allergens, ingredients, etc...) -->
                                 <div class="feed_composition">
                                     <t t-if="line.product_id.allergen_text">
-                                        <span class="info_title">Allergens: </span><t t-esc="line.product_id.allergen_text"/><br/>
+                                        <span class="info_title">Allergens:</span>&#160;<t t-esc="line.product_id.allergen_text"/><br/>
                                     </t>
                                     <t t-if="line.product_id.trace_allergen_text">
-                                        <span class="info_title">Traces: </span><t t-esc="line.product_id.trace_allergen_text"/><br/>
+                                        <span class="info_title">Traces:</span>&#160;<t t-esc="line.product_id.trace_allergen_text"/><br/>
                                     </t>
                                     <t t-if="line.product_id.ingredients">
-                                        <span class="info_title">Ingredients: </span><span t-raw="line.product_id.ingredients"/>
+                                        <span class="info_title">Ingredients:</span>&#160;<span t-raw="line.product_id.ingredients"/>
                                     </t>
                                 </div>
 

--- a/product_print_category_food_report/report/qweb_template_pricetag_template_C.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_template_C.xml
@@ -25,26 +25,27 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
                         <div class="pricetag_center">
 
+                                <!-- &#160; is useful to have space and not underline css under this space -->
                                 <!-- Manufacturing Location -->
                                 <div class="product_origin" t-if="line.product_id.pricetag_origin">
-                                    <span class="info_title">Manufacturing:</span><t t-esc="line.product_id.pricetag_origin"/>
+                                    <span class="info_title">Manufacturing:</span>&#160;<t t-esc="line.product_id.pricetag_origin"/>
                                 </div>
 
                                 <!-- Producer -->
                                 <div class="maker_description"  t-if="line.product_id.maker_description">
-                                    <span class="info_title">Producer:</span><t t-esc="line.product_id.maker_description"/>
+                                    <span class="info_title">Producer:</span>&#160;<t t-esc="line.product_id.maker_description"/>
                                 </div>
 
                                 <!-- Feed Composition (allergens, ingredients, etc...) -->
                                 <div class="feed_composition">
                                     <t t-if="line.product_id.allergen_text">
-                                        <span class="info_title">Allergens:</span><t t-esc="line.product_id.allergen_text"/><br/>
+                                        <span class="info_title">Allergens:</span>&#160;<t t-esc="line.product_id.allergen_text"/><br/>
                                     </t>
                                     <t t-if="line.product_id.trace_allergen_text">
-                                        <span class="info_title">Traces:</span><t t-esc="line.product_id.trace_allergen_text"/><br/>
+                                        <span class="info_title">Traces:</span>&#160;<t t-esc="line.product_id.trace_allergen_text"/><br/>
                                     </t>
                                     <t t-if="line.product_id.ingredients">
-                                        <span class="info_title">Ingredients:</span><span t-raw="line.product_id.ingredients"/>
+                                        <span class="info_title">Ingredients:</span>&#160;<span t-raw="line.product_id.ingredients"/>
                                     </t>
                                 </div>
 

--- a/product_print_category_food_report/report/qweb_template_pricetag_template_C.xml
+++ b/product_print_category_food_report/report/qweb_template_pricetag_template_C.xml
@@ -27,24 +27,24 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
                                 <!-- Manufacturing Location -->
                                 <div class="product_origin" t-if="line.product_id.pricetag_origin">
-                                    <span class="info_title">Manufacturing:</span>&#160;<t t-esc="line.product_id.pricetag_origin"/>
+                                    <span class="info_title">Manufacturing:</span><t t-esc="line.product_id.pricetag_origin"/>
                                 </div>
 
                                 <!-- Producer -->
                                 <div class="maker_description"  t-if="line.product_id.maker_description">
-                                    <span class="info_title">Producer:</span>&#160;<t t-esc="line.product_id.maker_description"/>
+                                    <span class="info_title">Producer:</span><t t-esc="line.product_id.maker_description"/>
                                 </div>
 
                                 <!-- Feed Composition (allergens, ingredients, etc...) -->
                                 <div class="feed_composition">
                                     <t t-if="line.product_id.allergen_text">
-                                        <span class="info_title">Allergens:</span>&#160;<t t-esc="line.product_id.allergen_text"/><br/>
+                                        <span class="info_title">Allergens:</span><t t-esc="line.product_id.allergen_text"/><br/>
                                     </t>
                                     <t t-if="line.product_id.trace_allergen_text">
-                                        <span class="info_title">Traces:</span>&#160;<t t-esc="line.product_id.trace_allergen_text"/><br/>
+                                        <span class="info_title">Traces:</span><t t-esc="line.product_id.trace_allergen_text"/><br/>
                                     </t>
                                     <t t-if="line.product_id.ingredients">
-                                        <span class="info_title">Ingredients:</span>&#160;<span t-raw="line.product_id.ingredients"/>
+                                        <span class="info_title">Ingredients:</span><span t-raw="line.product_id.ingredients"/>
                                     </t>
                                 </div>
 

--- a/product_print_category_food_report/static/src/scss/common.scss
+++ b/product_print_category_food_report/static/src/scss/common.scss
@@ -1,6 +1,6 @@
 .pricetag_product {
     font-family: Luciole;
-    margin : 0.03cm;
+    margin : 0.02cm;
     padding : 0.0cm;
     overflow: hidden;
     float: left;

--- a/product_print_category_food_report/static/src/scss/common.scss
+++ b/product_print_category_food_report/static/src/scss/common.scss
@@ -1,6 +1,6 @@
 .pricetag_product {
     font-family: Luciole;
-    margin : 0.0cm;
+    margin : 0.03cm;
     padding : 0.0cm;
     overflow: hidden;
     float: left;

--- a/product_print_category_food_report/static/src/scss/debug.scss
+++ b/product_print_category_food_report/static/src/scss/debug.scss
@@ -43,8 +43,12 @@
         background-color: #FFA;
 
     }
+    .feed_composition {
+        background-color: #ACF;
+
+    }
     .product_labels {
-        background-color: #AAF;
+        background-color: #AB0F29;
     }
 
     .organic_text {

--- a/product_print_category_food_report/static/src/scss/pricetag_0.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_0.scss
@@ -11,6 +11,9 @@
         }
     }
 
+    /* Image height is bigger than
+        zone height : permits to crop barcode
+        to make it smaller */
     .zone_barcode {
         height: 0.5cm;
 

--- a/product_print_category_food_report/static/src/scss/pricetag_0.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_0.scss
@@ -4,8 +4,9 @@
     .main_price {
 
         .main_price_text {
-            font-size: 22px;
+            font-weight: bold;
         }
+
         .main_uom_text {
             font-size: 12px;
         }

--- a/product_print_category_food_report/static/src/scss/pricetag_0.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_0.scss
@@ -2,10 +2,9 @@
     border: 1px solid grey;
 
     .main_price {
-        height: 0.7cm;
 
         .main_price_text {
-            font-size: 16px;
+            font-size: 22px;
         }
         .main_uom_text {
             font-size: 12px;
@@ -13,13 +12,13 @@
     }
 
     .zone_barcode {
-        height: 1.3cm;
+        height: 0.5cm;
 
         .wrap_barcode_image{
-            height: 1.2cm;
+            height: 1.5cm;
         }
         .wrap_barcode_image > img{
-            height: 1.2cm;
+            height: 1.5cm;
         }
     }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_01.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_01.scss
@@ -2,19 +2,23 @@
     width: 4.91cm;
     height: 4.42cm;
 
+    .main_price {
+        height: 1cm;
+    }
+
     .product_name{
         font-size:17px;
-        height: 1.42cm;
+        height: 1.9cm;
     }
 
     .secondary_price {
         height: 0.4cm;
-        font-size: 8px;
+        font-size: 9px;
     }
 
     .per_unit_quantity {
         height: 0.4cm;
-        font-size: 8px;
+        font-size: 9px;
     }
 
 }

--- a/product_print_category_food_report/static/src/scss/pricetag_01.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_01.scss
@@ -3,17 +3,23 @@
     height: 4.42cm;
 
     .main_price {
-        height: 1cm;
+        height: 1.2cm;
+
+        .main_price_text {
+            font-size: 30px;
+        }
+
     }
 
     .product_name{
-        font-size:17px;
-        height: 1.9cm;
+        font-size: 20px;
+        line-height: 0.8cm;
+        height: 1.5cm;
     }
 
     .secondary_price {
-        height: 0.4cm;
-        font-size: 9px;
+        height: 0.6cm;
+        font-size: 11px;
     }
 
     .per_unit_quantity {

--- a/product_print_category_food_report/static/src/scss/pricetag_01.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_01.scss
@@ -4,17 +4,17 @@
 
     .margin_top, .margin_bottom {
         width: 4.91cm;
-        height: 0.2cm;
+        height: 0.3cm;
     }
 
     .product_name{
         font-size: 17px;
-        line-height: 0.7cm;
-        height: 1.3cm;
+        line-height: 0.6cm;
+        height: 1.2cm;
     }
 
     .main_price {
-        height: 1.1cm;
+        height: 1cm;
 
         .main_price_text {
             font-size: 28px;

--- a/product_print_category_food_report/static/src/scss/pricetag_01.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_01.scss
@@ -2,23 +2,28 @@
     width: 4.91cm;
     height: 4.42cm;
 
+    .margin_top, .margin_bottom {
+        width: 4.91cm;
+        height: 0.2cm;
+    }
+
+    .product_name{
+        font-size: 17px;
+        line-height: 0.7cm;
+        height: 1.3cm;
+    }
+
     .main_price {
-        height: 1.2cm;
+        height: 1.1cm;
 
         .main_price_text {
-            font-size: 30px;
+            font-size: 28px;
         }
 
     }
 
-    .product_name{
-        font-size: 20px;
-        line-height: 0.8cm;
-        height: 1.5cm;
-    }
-
     .secondary_price {
-        height: 0.6cm;
+        height: 0.5cm;
         font-size: 11px;
     }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_02.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_02.scss
@@ -2,22 +2,27 @@
     width: 3.8cm;
     height: 3.8cm;
 
-    .main_price {
-        height: 0.9cm;
-
-        .main_price_text {
-            font-size: 26px;
-        }
+    .margin_top, .margin_bottom {
+        width: 3.8cm;
+        height: 0.2cm;
     }
 
     .product_name{
-        font-size: 17px;
+        font-size: 16px;
         line-height: 0.6cm;
-        height: 1.2cm;
+        height: 1.1cm;
+    }
+
+    .main_price {
+        height: 0.7cm;
+
+        .main_price_text {
+            font-size: 24px;
+        }
     }
 
     .secondary_price {
-        height: 0.6cm;
+        height: 0.5cm;
         font-size: 10px;
     }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_02.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_02.scss
@@ -3,17 +3,22 @@
     height: 3.8cm;
 
     .main_price {
-        height: 0.8cm;
+        height: 0.9cm;
+
+        .main_price_text {
+            font-size: 26px;
+        }
     }
 
     .product_name{
-        font-size:13px;
-        height: 1.5cm;
+        font-size: 17px;
+        line-height: 0.6cm;
+        height: 1.2cm;
     }
 
     .secondary_price {
-        height: 0.4cm;
-        font-size: 8px;
+        height: 0.6cm;
+        font-size: 10px;
     }
 
     .per_unit_quantity {

--- a/product_print_category_food_report/static/src/scss/pricetag_02.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_02.scss
@@ -2,19 +2,23 @@
     width: 3.8cm;
     height: 3.8cm;
 
+    .main_price {
+        height: 0.8cm;
+    }
+
     .product_name{
         font-size:13px;
-        height: 1.0cm;
+        height: 1.5cm;
     }
 
     .secondary_price {
-        height: 0.3cm;
-        font-size: 6px;
+        height: 0.4cm;
+        font-size: 8px;
     }
 
     .per_unit_quantity {
-        height: 0.3cm;
-        font-size: 6px;
+        height: 0.4cm;
+        font-size: 8px;
     }
 
 }

--- a/product_print_category_food_report/static/src/scss/pricetag_1.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_1.scss
@@ -1,6 +1,5 @@
-.pricetag_10, .pricetag_11, .pricetag_12 {
+.pricetag_10, .pricetag_11, .pricetag_12, .pricetag_40 {
     border: 1px solid black;
-    width: 9.3cm;
 
     .pricetag_left {
         width: 5.50cm;

--- a/product_print_category_food_report/static/src/scss/pricetag_1.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_1.scss
@@ -24,17 +24,17 @@
         }
 
         .product_labels {
-            height: 1cm;
+            height: 1.1cm;
 
             img.product_label {
-                width: 0.9cm;
-                height: 0.9cm;
+                width: 1.2cm;
+                height: 1.2cm;
                 margin: 0.1cm;
             }
         }
 
         .organic_text {
-            height: 0.6cm;
+            height: 0.5cm;
             font-size: 6px;
         }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_1.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_1.scss
@@ -5,6 +5,7 @@
     .pricetag_left {
         width: 5.50cm;
         height: 3.8cm;
+        padding-left: 0.2cm;
 
         .product_name{
             height: 1.2cm;
@@ -13,21 +14,21 @@
         }
 
         .product_origin {
-            height: 0.5cm;
+            height: 0.35cm;
             font-size: 8px;
         }
 
         .maker_description {
-            height: 0.5cm;
+            height: 0.35cm;
             font-size: 8px;
         }
 
         .product_labels {
-            height: 0.7cm;
+            height: 1cm;
 
             img.product_label {
-                width: 0.6cm;
-                height: 0.6cm;
+                width: 0.9cm;
+                height: 0.9cm;
                 margin: 0.1cm;
             }
         }

--- a/product_print_category_food_report/static/src/scss/pricetag_10.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_10.scss
@@ -1,4 +1,5 @@
 .pricetag_10 {
+    width: 9.3cm;
     height: 3.8cm;
 
     .margin_top, .margin_bottom {

--- a/product_print_category_food_report/static/src/scss/pricetag_11.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_11.scss
@@ -1,4 +1,5 @@
 .pricetag_11 {
+    width: 9.3cm;
     height: 4.4cm;
 
     .margin_top, .margin_bottom {

--- a/product_print_category_food_report/static/src/scss/pricetag_12.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_12.scss
@@ -1,4 +1,5 @@
 .pricetag_12 {
+    width: 9.3cm;
     height: 5.22cm;
 
     .margin_top, .margin_bottom {

--- a/product_print_category_food_report/static/src/scss/pricetag_20.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_20.scss
@@ -13,18 +13,18 @@
         padding-left: 0.1cm;
 
         .product_name{
-            height: 2.2cm;
-            font-size: 30px;
+            height: 3.3cm;
+            font-size: 40px;
             font-weight: bold;
         }
 
         .product_origin {
-            height: 1.2cm;
+            height: 0.5cm;
             font-size: 14px;
         }
 
         .maker_description {
-            height: 0.8cm;
+            height: 0.5cm;
             font-size: 14px;
         }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_20.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_20.scss
@@ -10,6 +10,7 @@
     .pricetag_left {
         width: 7.5cm;
         height: 6.8cm;
+        padding-left: 0.1cm;
 
         .product_name{
             height: 2.2cm;

--- a/product_print_category_food_report/static/src/scss/pricetag_3.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_3.scss
@@ -8,7 +8,9 @@
 
         .product_name {
             height: 100%;
-            font-size: 19px;
+            padding-top: 6px;
+            font-size: 25px;
+            line-height: 1;
             font-weight: bold;
         }
     }
@@ -21,7 +23,7 @@
         /* position relative permits to have labels at the bottom with absolute position */
 
         .info_title {
-            font-variant: small-caps;
+              text-decoration: underline;
         }
 
         .product_origin {

--- a/product_print_category_food_report/static/src/scss/pricetag_3.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_3.scss
@@ -10,7 +10,7 @@
             height: 100%;
             padding-top: 6px;
             font-size: 25px;
-            line-height: 1;
+            line-height: 1.1;
             font-weight: bold;
         }
     }
@@ -22,16 +22,15 @@
         position: relative;
         /* position relative permits to have labels at the bottom with absolute position */
 
-        .info_title {
-              text-decoration: underline;
-        }
-
         .feed_composition {
             overflow: hidden;
         }
 
+        /* no label = no height,
+            one or more label = white div hiding feed composition */
         .product_labels {
-            height: 1.4cm;
+            width: 100%;
+            background-color: white;
             position: absolute;
             bottom: 0;
 

--- a/product_print_category_food_report/static/src/scss/pricetag_3.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_3.scss
@@ -16,6 +16,13 @@
     .pricetag_center {
         width: 100%;
         border-bottom: 2px solid;
+        padding-left: 0.1cm;
+        position: relative;
+        /* position relative permits to have labels at the bottom with absolute position */
+
+        .info_title {
+            font-variant: small-caps;
+        }
 
         .product_origin {
             font-size: 13px;
@@ -27,10 +34,13 @@
 
         .feed_composition {
             font-size: 13px;
+            overflow: hidden;
         }
 
         .product_labels {
             height: 1.2cm;
+            position: absolute;
+            bottom: 0;
 
             img.product_label {
                 width: 1.0cm;
@@ -51,7 +61,8 @@
             border-right: 2px solid;
 
             .organic_text {
-                height: 0.8cm;
+                margin : 0.05cm 0.05cm;
+                height: 0.75cm;
                 font-size: 7px;
             }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_3.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_3.scss
@@ -1,4 +1,4 @@
-.pricetag_30, .pricetag_31, .pricetag_32 {
+.pricetag_30, .pricetag_31, .pricetag_32, .pricetag_33 {
 
     border: 2px solid black;
 
@@ -26,16 +26,7 @@
               text-decoration: underline;
         }
 
-        .product_origin {
-            font-size: 13px;
-        }
-
-        .maker_description {
-            font-size: 13px;
-        }
-
         .feed_composition {
-            font-size: 13px;
             overflow: hidden;
         }
 
@@ -68,16 +59,23 @@
                 font-size: 7px;
             }
 
+            /* Image height is bigger than
+                zone height : permits to crop barcode
+                to make it smaller
+                Position relative permits to
+                go up barcode and display code number */
             .zone_barcode {
-                height: 1.5cm;
+                height: 1.2cm;
 
                 .wrap_barcode_image{
-                    height: 1.4cm;
+                    height: 1.5cm;
                     width: 3.0cm;
                 }
                 .wrap_barcode_image > img{
-                    height: 1.4cm;
+                    height: 1.5cm;
                     width: 3.0cm;
+                    position: relative;
+                    bottom: 15px
                 }
             }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_3.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_3.scss
@@ -31,13 +31,13 @@
         }
 
         .product_labels {
-            height: 1.2cm;
+            height: 1.4cm;
             position: absolute;
             bottom: 0;
 
             img.product_label {
-                width: 1.0cm;
-                height: 1.0cm;
+                width: 1.2cm;
+                height: 1.2cm;
                 margin: 0.1cm;
             }
         }

--- a/product_print_category_food_report/static/src/scss/pricetag_30.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_30.scss
@@ -18,10 +18,6 @@
             max-height: 1.0cm;
         }
 
-        .feed_composition {
-            max-height: 3.98cm;
-        }
-
     }
 
     .pricetag_bottom {

--- a/product_print_category_food_report/static/src/scss/pricetag_30.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_30.scss
@@ -8,6 +8,7 @@
 
     .pricetag_center {
         height: 7.08cm;
+        font-size: 13px;
 
         .product_origin {
             max-height: 1.0cm;

--- a/product_print_category_food_report/static/src/scss/pricetag_30.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_30.scss
@@ -3,11 +3,11 @@
     height: 12.38cm;
 
     .pricetag_top {
-        height: 2.2cm;
+        height: 2.3cm;
     }
 
     .pricetag_center {
-        height: 7.18cm;
+        height: 7.08cm;
 
         .product_origin {
             max-height: 1.0cm;

--- a/product_print_category_food_report/static/src/scss/pricetag_30.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_30.scss
@@ -20,8 +20,6 @@
         .feed_composition {
             max-height: 3.98cm;
         }
-        .product_labels {
-        }
 
     }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_31.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_31.scss
@@ -20,11 +20,6 @@
             max-height: 1.0cm;
         }
 
-        .feed_composition {
-            height: 3.72cm;
-            max-height: 3.98cm;
-        }
-
     }
 
     .pricetag_bottom {

--- a/product_print_category_food_report/static/src/scss/pricetag_31.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_31.scss
@@ -3,11 +3,11 @@
     height: 10.42cm;
 
     .pricetag_top {
-        height: 1.6cm;
+        height: 1.7cm;
     }
 
     .pricetag_center {
-        height: 6.02cm;
+        height: 5.92cm;
 
         .product_origin {
             height: 0.5cm;
@@ -18,7 +18,7 @@
         }
 
         .feed_composition {
-            height: 3.82cm;
+            height: 3.72cm;
         }
 
     }

--- a/product_print_category_food_report/static/src/scss/pricetag_32.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_32.scss
@@ -8,6 +8,7 @@
 
     .pricetag_center {
         height: 6.68cm;
+        font-size: 13px;
 
         .product_origin {
             height: 0.5cm;

--- a/product_print_category_food_report/static/src/scss/pricetag_32.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_32.scss
@@ -3,11 +3,11 @@
     height: 11.28cm;
 
     .pricetag_top {
-        height: 1.6cm;
+        height: 1.8cm;
     }
 
     .pricetag_center {
-        height: 6.88cm;
+        height: 6.68cm;
 
         .product_origin {
             height: 0.5cm;
@@ -18,7 +18,7 @@
         }
 
         .feed_composition {
-            height: 4.68cm;
+            height: 4.48cm;
         }
 
     }

--- a/product_print_category_food_report/static/src/scss/pricetag_32.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_32.scss
@@ -18,10 +18,6 @@
             height: 0.5cm;
         }
 
-        .feed_composition {
-            height: 4.48cm;
-        }
-
     }
 
     .pricetag_bottom {

--- a/product_print_category_food_report/static/src/scss/pricetag_33.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_33.scss
@@ -1,28 +1,25 @@
-.pricetag_31 {
-    width: 11.28cm;
-    height: 10.42cm;
+.pricetag_33 {
+    width: 8cm;
+    height: 8cm;
 
     .pricetag_top {
-        height: 1.7cm;
+        height: 1.6cm;
     }
 
     .pricetag_center {
-        height: 5.92cm;
-        font-size: 13px;
+        height: 4.1cm;
+        font-size: 9px;
 
         .product_origin {
             height: 0.5cm;
-            max-height: 1.0cm;
         }
 
         .maker_description {
             height: 0.5cm;
-            max-height: 1.0cm;
         }
 
         .feed_composition {
-            height: 3.72cm;
-            max-height: 3.98cm;
+            height: 3.5cm;
         }
 
     }
@@ -39,16 +36,17 @@
 
             .shop_information {
                 height: 0.5cm;
+                font-size: 6px;
             }
         }
         .pricetag_bottom_right {
             width: 60%;
 
             .main_price {
-                height: 1.6cm;
+                height: 1.5cm;
 
                 .main_price_text {
-                    font-size: 36px;
+                    font-size: 26px;
                 }
             }
 

--- a/product_print_category_food_report/static/src/scss/pricetag_33.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_33.scss
@@ -19,7 +19,7 @@
         }
 
         .feed_composition {
-            height: 3.5cm;
+            max-height: 3.5cm;
         }
 
     }
@@ -43,7 +43,7 @@
             width: 60%;
 
             .main_price {
-                height: 1.5cm;
+                height: 1cm;
 
                 .main_price_text {
                     font-size: 26px;

--- a/product_print_category_food_report/static/src/scss/pricetag_40.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_40.scss
@@ -1,0 +1,80 @@
+.pricetag_40 {
+    border: 1px solid black;
+    width: 7.2cm;
+    height: 2.9cm;
+
+    .margin_top, .margin_bottom {
+        width: 7.2cm;
+        height: 0.2cm;
+    }
+
+    .product_labels{
+        display: none;
+    }
+
+    .pricetag_left {
+        width: 4.1cm;
+        height: 2.9cm;
+        padding-left: 0.2cm;
+
+        .product_name{
+            height: 1.8cm;
+            font-size: 15px;
+            font-weight: bold;
+        }
+
+        .product_origin {
+            height: 0.38cm;
+            font-size: 8px;
+        }
+
+        .maker_description {
+            height: 0.38cm;
+            font-size: 8px;
+        }
+
+        .product_labels, .organic_text, .shop_information {
+            display: none;
+        }
+
+    }
+    .pricetag_right {
+        width: 2.9cm;
+        height: 2.9cm;
+
+        .main_price {
+            height: 1.4cm;
+
+            .main_price_text {
+                font-size: 25px;
+                font-weight: bold;
+            }
+            .main_uom_text {
+                display: inline-block;
+                font-size: 12px;
+            }
+        }
+
+        .per_unit_quantity {
+            height: 1.5cm;
+            width: 50%;
+            font-size: 10px;
+            float: left;
+
+        }
+
+        .secondary_price {
+            height: 1.5cm;
+            width: 50%;
+            font-size: 10px;
+            float: left;
+        }
+
+        .zone_barcode {
+            display: none;
+        }
+
+    }
+
+
+}

--- a/product_print_category_food_report/static/src/scss/pricetag_40.scss
+++ b/product_print_category_food_report/static/src/scss/pricetag_40.scss
@@ -43,7 +43,7 @@
         height: 2.9cm;
 
         .main_price {
-            height: 1.4cm;
+            height: 1.6cm;
 
             .main_price_text {
                 font-size: 25px;
@@ -56,7 +56,7 @@
         }
 
         .per_unit_quantity {
-            height: 1.5cm;
+            height: 1.3cm;
             width: 50%;
             font-size: 10px;
             float: left;
@@ -64,7 +64,7 @@
         }
 
         .secondary_price {
-            height: 1.5cm;
+            height: 1.3cm;
             width: 50%;
             font-size: 10px;
             float: left;


### PR DESCRIPTION
[Ticket 1156](https://erp.grap.coop/web#id=1156&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673)

Correctif sur les étiquettes, suite aux grosses modifications en Juin.

- Tous les formats : espace entre chaque étiquette pour mieux gérer la découpe
- Formats Étagère carré :
   - plus petit code barre
   - plus gros nom de produit sur 2 lignes au lieu de 3
   - marge en haut et en bas
- Formats Étagère rectangulaire : espace plus petit entre Fabrication et Fabricant·e, et labels plus gros
- Format Comptoir : nom du produit plus gros
- Formats Vrac : 
   - nom de produit plus gros
   - champ ingrédients ne dépasse plus,
   - labels collé en bas du centre de l'étiquette
- ☀️ 2 nouveaux format d'étiquettes
   - pour les vraciers Mobilwood n°33 : 68x68mm
   - pour les produits emballés ne nécessitant ni label ni code-barre n°40 : 61x24mm