### PR TITLE
[16.0][FIX] partner_hide_technical_user: allow user to write on the partner related to his user, even if he is no member of 'Administration / Access' group.

### DIFF
--- a/partner_hide_technical_user/models/res_partner.py
+++ b/partner_hide_technical_user/models/res_partner.py
@@ -35,17 +35,29 @@ class ResPartner(models.Model):
         users = ResUsers.with_context(active_test=False).search(
             [("partner_id", "in", self.ids)]
         )
-        if len(users):
-            # Check if current user has correct access right
-            if not self.env.user.has_group("base.group_erp_manager"):
-                raise UserError(
-                    _(
-                        "You must be part of the group Administration / Access"
-                        " Rights to update partners associated to"
-                        " users.\n- %s"
-                    )
-                    % ("\n- ".join(users.mapped("name")))
+        if not users:
+            return
+
+        if users.ids == self.env.user.ids and self.env.context.get(
+            "write_user_mode", False
+        ):
+            # The unique partner changed is the partner related
+            # to the current user
+            # AND the write is done via the write of the res.users.
+            # so it's a allowed write, done to change some personal fields
+            # like 'email', 'tz', etc.
+            return
+
+        # Check if current user has correct access right
+        if not self.env.user.has_group("base.group_erp_manager"):
+            raise UserError(
+                _(
+                    "You must be part of the group Administration / Access"
+                    " Rights to update partners associated to"
+                    " users.\n- %s"
                 )
+                % ("\n- ".join(users.mapped("name")))
+            )
 
     # Overload the private _search function:
     # This function is used by the other ORM functions

--- a/partner_hide_technical_user/models/res_users.py
+++ b/partner_hide_technical_user/models/res_users.py
@@ -14,3 +14,6 @@ class ResUsers(models.Model):
         for vals in vals_list:
             vals.update({"is_odoo_user": True})
         return super().create(vals_list)
+
+    def write(self, vals):
+        return super(ResUsers, self.with_context(write_user_mode=True)).write(vals)

--- a/partner_hide_technical_user/tests/test_module.py
+++ b/partner_hide_technical_user/tests/test_module.py
@@ -14,24 +14,16 @@ class TestModule(TransactionCase):
         cls.ResUsers = cls.env["res.users"]
         cls.demo_user = cls.env.ref("base.user_demo")
         cls.demo_partner = cls.env.ref("base.partner_demo")
-        cls.main_company = cls.env.ref("base.main_company")
         cls.user_name = "technical_partner_access - res.users"
-
-    def test_01_user_part(self):
-        user = self.ResUsers.create(
+        cls.user = cls.ResUsers.create(
             {
-                "name": self.user_name,
+                "name": cls.user_name,
                 "login": "login@users_partners_access.com",
-                "company_id": self.main_company.id,
+                "company_id": cls.env.ref("base.main_company").id,
             }
         )
-        # check that partner has no company
-        self.assertEqual(
-            user.partner_id.company_id.id,
-            False,
-            "User's partner should not have company.",
-        )
 
+    def test_01_search_partner(self):
         # Check access without context (by search)
         result = self.ResPartner.search([("name", "=", self.user_name)])
         self.assertEqual(
@@ -64,9 +56,15 @@ class TestModule(TransactionCase):
             len(result), 1, "Name Search user partner should return result with context"
         )
 
-        # Without Correct access right, should fail
+    def test_02_write_on_partner_without_right(self):
+        # Without Correct access right, write should fail
         with self.assertRaises(UserError):
             self.demo_partner.with_user(self.demo_user).write({"name": "Test"})
 
+        # A user should have the possibility to write to his
+        # related partner
+        self.demo_user.with_user(self.demo_user).write({"tz": "Europe/Paris"})
+
+    def test_03_write_on_partner_with_right(self):
         # With Correct access right, should success
         self.demo_partner.write({"name": "Test"})


### PR DESCRIPTION
 It so allow users to change basic fields for him self, like 'tz', 'email', etc...