### PR TITLE
[REF] product_label: use new image.mixin

### DIFF
--- a/product_label/__manifest__.py
+++ b/product_label/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Product Labels",
-    "version": "16.0.1.0.1",
+    "version": "16.0.2.0.0",
     "category": "Product",
     "author": "GRAP",
     "maintainers": ["legalsylvain", "quentinDupont"],

--- a/product_label/migrations/16.0.2.0.0/post-migration.py
+++ b/product_label/migrations/16.0.2.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2024 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    # Force to recompute images
+    for label in env["product.label"].search([("id", "!=", 0)]):
+        if label.image_1920:
+            label.write({"image_1920": label.image_1920})

--- a/product_label/migrations/16.0.2.0.0/pre-migration.py
+++ b/product_label/migrations/16.0.2.0.0/pre-migration.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_field_renames = [
+    ("product.label", "product_label", "image", "image_1920"),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(env, _field_renames)

--- a/product_label/models/product_label.py
+++ b/product_label/models/product_label.py
@@ -8,6 +8,7 @@ from odoo import api, fields, models
 
 class ProductLabel(models.Model):
     _name = "product.label"
+    _inherit = ["image.mixin"]
     _description = "Product Labels"
 
     # Columns Section
@@ -39,14 +40,6 @@ class ProductLabel(models.Model):
 
     product_qty = fields.Integer(
         string="Product Quantity", compute="_compute_product_qty"
-    )
-
-    image = fields.Image(max_width=1920, max_height=1920)
-    image_medium = fields.Image(
-        related="image", max_width=512, max_height=512, store=True
-    )
-    image_small = fields.Image(
-        related="image", max_width=128, max_height=128, store=True
     )
 
     @api.depends("product_ids")

--- a/product_label/views/view_product_label.xml
+++ b/product_label/views/view_product_label.xml
@@ -53,7 +53,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger"
                             attrs="{'invisible': [('active', '=', True)]}"/>
 
-                    <field name="image" widget="image" class="oe_avatar" options="{'preview_image': 'image_medium'}"/>
+                    <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                     <div class="oe_title">
                         <label for="name" string="Label Name"/>
                         <h1>
@@ -83,12 +83,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <field name="id"/>
                 <field name="code"/>
                 <field name="name"/>
-                <field name="image_small"/>
+                <field name="image_128"/>
                 <field name="product_qty"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_res_partner_kanban">
-                            <img class="o_kanban_image" t-att-src="kanban_image('product.label', 'image_small', record.id.raw_value)" t-att-alt="record.name"/>
+                            <img class="o_kanban_image" t-att-src="kanban_image('product.label', 'image_128', record.id.raw_value)" t-att-alt="record.name"/>
 
                             <div class="oe_kanban_details">
                                 <strong class="o_kanban_record_title oe_partner_heading">


### PR DESCRIPTION
En essayant de corriger une erreur dans un log de odoo de prod', j'ai découvert l'existence d'un nouveau mixin. (image.mixin que j'ai implémenté).

**Warning dans les logs**

<code>
2024-11-15 10:58:45,249 99101 WARNING product_label_16_before odoo.addons.base.models.ir_model: Two fields (image_medium, image) of product.label() have the same label: Image. [Modules: product_label and product_label] 
2024-11-15 10:58:45,249 99101 WARNING product_label_16_before odoo.addons.base.models.ir_model: Two fields (image_small, image) of product.label() have the same label: Image. [Modules: product_label and product_label] 

</code>
