### PR TITLE
[FIX] add groups to private field

### DIFF
--- a/hr_direct_address_home/models/hr_employee.py
+++ b/hr_direct_address_home/models/hr_employee.py
@@ -13,6 +13,7 @@ class HrEmployee(models.Model):
         string="Street (Private)",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -20,6 +21,7 @@ class HrEmployee(models.Model):
         string="Street 2 (Private)",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -28,6 +30,7 @@ class HrEmployee(models.Model):
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
         store=True,
+        groups="hr.group_hr_user",
     )
 
     address_home_state_id = fields.Many2one(
@@ -37,6 +40,7 @@ class HrEmployee(models.Model):
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
         domain="[('country_id', '=?', country_id)]",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -44,6 +48,7 @@ class HrEmployee(models.Model):
         string="ZIP (Private)",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -53,6 +58,7 @@ class HrEmployee(models.Model):
         ondelete="restrict",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -60,6 +66,7 @@ class HrEmployee(models.Model):
         string="Phone (Private)",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -67,6 +74,7 @@ class HrEmployee(models.Model):
         string="Mobile (Private)",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 
@@ -74,6 +82,7 @@ class HrEmployee(models.Model):
         string="Email (Private)",
         compute="_compute_address_home_details",
         inverse="_inverse_address_home_details",
+        groups="hr.group_hr_user",
         store=True,
     )
 


### PR DESCRIPTION
FIX le bug au moment de la validation de la dépense
<img width="1088" height="254" alt="image" src="https://github.com/user-attachments/assets/7d69d3c7-9b16-4d29-9e06-eae774e6f6b3" />

issu du code odoo :

```
    class HrEmployeePrivate(models.Model):
        """
        NB: Any field only available on the model hr.employee (i.e. not on the
        hr.employee.public model) should have `groups="hr.group_hr_user"` on its
        definition to avoid being prefetched when the user hasn't access to the
        hr.employee model. Indeed, the prefetch loads the data for all the fields
        that are available according to the group defined on them.
        """
```