### PR TITLE
[FIX] sale_recory_moment & sale_eshop: do not replace product.product by product.template, without migration script

### DIFF
--- a/sale_eshop/models/sale_order.py
+++ b/sale_eshop/models/sale_order.py
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
             _place = sale.recovery_moment_id.place_id
             sale.recovery_name = _place.name
             sale.recovery_extra_cost = (
-                _place.shipping_product_id.product_variant_ids[0].list_price
+                _place.shipping_product_id.list_price
                 if _place.shipping_product_id
                 else 0
             )

--- a/sale_recovery_moment/README.rst
+++ b/sale_recovery_moment/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://odoo-community.org/readme-banner-image
+   :target: https://odoo-community.org/get-involved?utm_source=readme
+   :alt: Odoo Community Association
+
 =======================
 Sale - Recovery Moments
 =======================
@@ -13,7 +17,7 @@ Sale - Recovery Moments
 .. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
     :alt: Beta
-.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-grap%2Fgrap--odoo--business-lightgray.png?logo=github

--- a/sale_recovery_moment/__manifest__.py
+++ b/sale_recovery_moment/__manifest__.py
@@ -33,7 +33,7 @@
         "reports/report_print_picking_summary_template.xml",
     ],
     "demo": [
-        "demo/product_template.xml",
+        "demo/product_product.xml",
         "demo/sale_recovery_place.xml",
         "demo/sale_recovery_moment_group.xml",
         "demo/sale_recovery_moment.xml",

--- a/sale_recovery_moment/demo/product_product.xml
+++ b/sale_recovery_moment/demo/product_product.xml
@@ -6,7 +6,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
 
-    <record id="product_shipping_cost" model="product.template">
+    <record id="product_shipping_cost" model="product.product">
         <field name="name">Shipping Cost</field>
         <field name="type">service</field>
         <field name="list_price" eval="1.5"/>

--- a/sale_recovery_moment/models/sale_order.py
+++ b/sale_recovery_moment/models/sale_order.py
@@ -43,15 +43,13 @@ class SaleOrder(models.Model):
         for order in self.filtered(
             lambda x: x.recovery_moment_id.place_id.shipping_product_id
         ):
-            _place = order.recovery_moment_id.place_id
-            product = _place.shipping_product_id.product_variant_ids[0]
-            if product:
-                SaleOrderLine.create(
-                    {
-                        "order_id": order.id,
-                        "product_id": product.id,
-                    }
-                )
+            product = order.recovery_moment_id.place_id.shipping_product_id
+            SaleOrderLine.create(
+                {
+                    "order_id": order.id,
+                    "product_id": product.id,
+                }
+            )
 
         return super().action_confirm()
 

--- a/sale_recovery_moment/models/sale_recovery_place.py
+++ b/sale_recovery_moment/models/sale_recovery_place.py
@@ -39,7 +39,7 @@ class SaleRecoveryPlace(models.Model):
 
     shipping_product_id = fields.Many2one(
         string="Shipping Cost Product",
-        comodel_name="product.template",
+        comodel_name="product.product",
         domain="[('type', '=', 'service')]",
         help="If set, this product will"
         " be added automatically to the sale order, when it is confirmed,"


### PR DESCRIPTION
pas très bien compris la raison du changement product -> template.

ça fait péter la migration 12 -> 16, car il n'y a pas de script de migration adéquat.

retrait du changement, en attente d'une rediscussion avec quentin.