### PR TITLE
[FIX] eshop : inline view searched view differently from tree view

### DIFF
--- a/sale_eshop/models/product_product.py
+++ b/sale_eshop/models/product_product.py
@@ -125,7 +125,6 @@ class ProductProduct(models.Model):
     # API eshop Section
     @api.model
     def get_current_eshop_product_list(self, partner_id=False):
-        today = fields.Date.context_today(self)
         SaleOrder = self.env["sale.order"]
         Product = self.env["product.product"]
 
@@ -137,7 +136,6 @@ class ProductProduct(models.Model):
                     "qty": line.product_uom_qty,
                     "discount": line.discount,
                 }
-
 
         products = Product.search(
             [

--- a/sale_eshop/models/product_product.py
+++ b/sale_eshop/models/product_product.py
@@ -138,17 +138,11 @@ class ProductProduct(models.Model):
                     "discount": line.discount,
                 }
 
+
         products = Product.search(
             [
-                ("active", "=", True),
-                ("product_tmpl_id.sale_ok", "=", True),
-                ("product_tmpl_id.company_id", "=", self.env.company.id),
-                "|",
-                ("eshop_start_date", "=", False),
-                ("eshop_start_date", "<=", today),
-                "|",
-                ("eshop_end_date", "=", False),
-                ("eshop_end_date", ">=", today),
+                ("eshop_state", "=", "available"),
+                ("eshop_category_id", "!=", False),
             ]
         )
 


### PR DESCRIPTION
[Internal task 2263](https://erp.grap.coop/web#id=2263&action=2148&active_id=40&model=project.task&view_type=form&menu_id=1673)

This commit permits to be consistent with tree view : https://github.com/grap/odoo-eshop/blob/16.0/odoo_eshop/eshop_app/controllers/controller_catalog.py#L27