### PR TITLE
[REF] mrp_product_price_quick_menus, add company_id field invisible;

### DIFF
--- a/mrp_product_price_quick_menus/views/view_product_product.xml
+++ b/mrp_product_price_quick_menus/views/view_product_product.xml
@@ -76,6 +76,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
               <button name="use_theoretical_price" type="object" string="Apply Margin" icon="fa-arrow-down" attrs="{'invisible': [('margin_state', '!=', 'too_expensive')]}" help="Decrease the Sale Price down to Theoretical Price"/>
               <field name="theoretical_difference" string="Theorical&#160;difference" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}"/>
               <field name="company_id" groups="base.group_multi_company" readonly="1"/>
+              <field name="company_id" invisible="1"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Rational: margin_classification_id now is check_company. As a result, company_id has be allways available, even for user that are not member of multicompany group

ref : https://github.com/OCA/margin-analysis/pull/272